### PR TITLE
Implement modular transcription pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,88 @@
 # oratiotranscripta
+
 Pipeline em Python para transcrição e anotação automática de áudio, integrando Whisper, pyannote e outras ferramentas open-source para converter fala em texto e estruturar metadados de forma eficiente.
+
+## Recursos principais
+
+- **Ingestão flexível**: suporte a arquivos locais ou YouTube (`yt-dlp`) com normalização automática de áudio via `ffmpeg`.
+- **Detecção de voz (VAD)**: backends selecionáveis (`webrtc`, `silero`, `pyannote`) com possibilidade de bypass.
+- **Reconhecimento de fala (ASR)**: escolha entre Whisper oficial ou Faster-Whisper (CTranslate2) com seleção automática de CPU/GPU.
+- **Alinhamento opcional**: integração com WhisperX para produzir timestamps de palavras de alta precisão.
+- **Diarização**: heurísticas básicas de energia/pausa ou pipeline pré-treinado do `pyannote.audio` (requer token HF).
+- **Agregação flexível**: preserva segmentos originais ou gera blocos temporais fixos (`--window`) adequados para legendas.
+- **Exportação rica**: gera `.txt`, `.srt`, `.vtt` e `.json` com metadados de speakers, confidences e timestamps.
+
+## Instalação
+
+```bash
+pip install .[all]  # instala o pacote e todas as dependências opcionais
+```
+
+Para instalações mínimas use apenas o conjunto de extras necessário, por exemplo `pip install .[asr]`.
+
+Certifique-se de ter `ffmpeg` disponível no PATH para normalização e extração de áudio.
+
+## Uso via CLI
+
+O módulo inclui um CLI baseado em `argparse`. Execute:
+
+```bash
+python -m oratiotranscripta --help
+```
+
+Opções principais:
+
+| Opção | Descrição |
+|-------|-----------|
+| `--source {local,youtube}` | Define a origem do áudio (default: `local`). |
+| `--path PATH` | Caminho para arquivo local quando `--source=local`. |
+| `--url URL` | URL do vídeo quando `--source=youtube`. |
+| `--out PATH` | Caminho base dos arquivos de saída (padrão: `output`). |
+| `--model NAME` | Modelo Whisper/Faster-Whisper a ser utilizado. |
+| `--engine {whisper,faster-whisper}` | Backend de ASR. |
+| `--lang CODE` | Força idioma específico para a transcrição. |
+| `--cookies PATH` | Arquivo de cookies (yt-dlp). |
+| `--export ...` | Formatos de exportação (`txt`, `srt`, `vtt`, `json`). |
+| `--window SEC` | Gera janelas fixas para legendas. |
+| `--vad BACKEND` | Backend de VAD (`auto`, `webrtc`, `silero`, `pyannote`, `none`). |
+| `--diarize {none,basic,pyannote}` | Método de diarização. |
+| `--pyannote-token TOKEN` | Token HF usado em VAD/Diarização pyannote. |
+| `--align` | Habilita alinhamento de palavras com WhisperX. |
+| `--words` | Solicita metadados de palavras quando suportado pelo modelo ASR. |
+| `--keep-temp` | Mantém diretórios temporários gerados. |
+| `--verbose` | Ativa logs detalhados. |
+
+### Exemplo
+
+Transcrever arquivo local com Whisper base, gerar legendas em SRT e JSON, diarização básica e janelas de 30 segundos:
+
+```bash
+python -m oratiotranscripta \
+  --source local \
+  --path ./audio.wav \
+  --model base \
+  --engine whisper \
+  --export srt json \
+  --diarize basic \
+  --window 30
+```
+
+Para baixar do YouTube com Faster-Whisper e VAD Silero:
+
+```bash
+python -m oratiotranscripta \
+  --source youtube \
+  --url https://youtu.be/xxxx \
+  --engine faster-whisper \
+  --model medium \
+  --vad silero \
+  --export txt vtt
+```
+
+## Desenvolvimento
+
+- O pacote está organizado em submódulos (`ingest`, `vad`, `asr`, `alignment`, `diarization`, `aggregation`, `export`), permitindo substituições e extensões pontuais.
+- Dependências pesadas são opcionais e só precisam ser instaladas quando o recurso correspondente for utilizado.
+- Scripts CLI podem ser executados via `python -m oratiotranscripta` ou com o entry-point instalado `oratiotranscripta`.
+
+Sinta-se à vontade para abrir issues ou PRs com melhorias e integrações adicionais.

--- a/oratiotranscripta/__init__.py
+++ b/oratiotranscripta/__init__.py
@@ -1,0 +1,12 @@
+"""OratioTranscripta - pipeline modular."""
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("oratiotranscripta")
+except PackageNotFoundError:  # pragma: no cover - fallback when run from source
+    __version__ = "0.1.0"
+
+from .cli import main
+
+__all__ = ["main", "__version__"]

--- a/oratiotranscripta/__main__.py
+++ b/oratiotranscripta/__main__.py
@@ -1,0 +1,6 @@
+"""Entry-point for ``python -m oratiotranscripta``."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/oratiotranscripta/aggregation/__init__.py
+++ b/oratiotranscripta/aggregation/__init__.py
@@ -1,0 +1,82 @@
+"""Aggregation of transcription segments."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from ..asr import TranscriptionSegment, WordMetadata
+
+
+@dataclass
+class AggregationConfig:
+    window: Optional[float] = None
+
+
+def aggregate_segments(
+    segments: Iterable[TranscriptionSegment],
+    config: AggregationConfig,
+) -> List[TranscriptionSegment]:
+    segment_list = [s for s in segments]
+    if not segment_list:
+        return []
+    if not config.window:
+        return [
+            TranscriptionSegment(
+                start=segment.start,
+                end=segment.end,
+                text=segment.text,
+                confidence=segment.confidence,
+                speaker=segment.speaker,
+                words=[WordMetadata(**vars(word)) for word in segment.words],
+            )
+            for segment in segment_list
+        ]
+
+    window = float(config.window)
+    base_start = math.floor(segment_list[0].start / window) * window
+    grouped: Dict[int, List[TranscriptionSegment]] = defaultdict(list)
+    for segment in segment_list:
+        index = int((segment.start - base_start) // window)
+        grouped[index].append(segment)
+
+    aggregated: List[TranscriptionSegment] = []
+    for index in sorted(grouped):
+        group = grouped[index]
+        start = base_start + index * window
+        end = min(start + window, group[-1].end)
+        text_lines: List[str] = []
+        current_speaker = None
+        combined_words: List[WordMetadata] = []
+        confidences: List[float] = []
+
+        for seg in group:
+            prefix = f"{seg.speaker}: " if seg.speaker else ""
+            if current_speaker == seg.speaker and text_lines:
+                text_lines[-1] += " " + seg.text.strip()
+            else:
+                text_lines.append(prefix + seg.text.strip())
+            current_speaker = seg.speaker
+            combined_words.extend(seg.words)
+            if seg.confidence is not None:
+                confidences.append(seg.confidence)
+        text = "\n".join(filter(None, text_lines))
+        confidence = sum(confidences) / len(confidences) if confidences else None
+        speaker = group[0].speaker if all(seg.speaker == group[0].speaker for seg in group) else None
+        aggregated.append(
+            TranscriptionSegment(
+                start=start,
+                end=end,
+                text=text,
+                confidence=confidence,
+                speaker=speaker,
+                words=[WordMetadata(**vars(word)) for word in combined_words],
+            )
+        )
+
+    return aggregated
+
+
+__all__ = ["AggregationConfig", "aggregate_segments"]

--- a/oratiotranscripta/alignment/__init__.py
+++ b/oratiotranscripta/alignment/__init__.py
@@ -1,0 +1,86 @@
+"""Optional alignment utilities using WhisperX."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..asr import TranscriptionResult, WordMetadata
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AlignmentConfig:
+    enabled: bool = False
+    model: str = "WAV2VEC2_ASR_LARGE_LV60K_960H"
+    device: Optional[str] = None
+    language: Optional[str] = None
+
+
+class AlignmentError(RuntimeError):
+    """Raised when alignment cannot be completed."""
+
+
+def align_transcription(
+    result: TranscriptionResult,
+    audio_path: Path,
+    config: AlignmentConfig,
+) -> TranscriptionResult:
+    """Apply WhisperX alignment to an existing transcription result."""
+
+    if not config.enabled:
+        return result
+
+    try:
+        import whisperx  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise AlignmentError("whisperx não está instalado") from exc
+
+    device = config.device or ("cuda" if whisperx.is_cuda_available() else "cpu")
+    logger.info("Iniciando alinhamento WhisperX (%s)", device)
+    align_model, metadata = whisperx.load_align_model(
+        language=config.language or result.language,
+        device=device,
+        model_name=config.model,
+    )
+    audio = whisperx.load_audio(str(audio_path))
+
+    whisperx_result = {
+        "language": result.language,
+        "segments": [
+            {
+                "start": segment.start,
+                "end": segment.end,
+                "text": segment.text,
+            }
+            for segment in result.segments
+        ],
+    }
+
+    aligned = whisperx.align(whisperx_result["segments"], align_model, metadata, audio, device)
+    words_by_segment = aligned["segments"]
+
+    for segment, aligned_segment in zip(result.segments, words_by_segment):
+        words = []
+        for word in aligned_segment.get("words", []):
+            words.append(
+                WordMetadata(
+                    word=word.get("word", ""),
+                    start=word.get("start"),
+                    end=word.get("end"),
+                    confidence=word.get("score"),
+                )
+            )
+        segment.words = words
+
+    result.metadata["alignment"] = {
+        "model": config.model,
+        "device": device,
+    }
+    return result
+
+
+__all__ = ["AlignmentConfig", "AlignmentError", "align_transcription"]

--- a/oratiotranscripta/asr/__init__.py
+++ b/oratiotranscripta/asr/__init__.py
@@ -1,0 +1,264 @@
+"""Automatic speech recognition interfaces."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from ..vad import VADSegment
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WordMetadata:
+    """Metadata for a recognised word."""
+
+    word: str
+    start: Optional[float]
+    end: Optional[float]
+    confidence: Optional[float] = None
+
+
+@dataclass
+class TranscriptionSegment:
+    """Segment of recognised speech."""
+
+    start: float
+    end: float
+    text: str
+    confidence: Optional[float] = None
+    speaker: Optional[str] = None
+    words: List[WordMetadata] = field(default_factory=list)
+
+
+@dataclass
+class TranscriptionResult:
+    segments: List[TranscriptionSegment]
+    language: Optional[str]
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "language": self.language,
+            "segments": [
+                {
+                    "start": segment.start,
+                    "end": segment.end,
+                    "text": segment.text,
+                    "confidence": segment.confidence,
+                    "speaker": segment.speaker,
+                    "words": [
+                        {
+                            "word": word.word,
+                            "start": word.start,
+                            "end": word.end,
+                            "confidence": word.confidence,
+                        }
+                        for word in segment.words
+                    ],
+                }
+                for segment in self.segments
+            ],
+            "metadata": self.metadata,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=2)
+
+
+class BaseASREngine:
+    def transcribe(
+        self,
+        audio_path: Path,
+        *,
+        language: Optional[str] = None,
+        vad_segments: Optional[Sequence[VADSegment]] = None,
+        word_timestamps: bool = False,
+    ) -> TranscriptionResult:
+        raise NotImplementedError
+
+
+def load_asr_engine(
+    engine: str,
+    model: str,
+    *,
+    device: Optional[str] = None,
+) -> BaseASREngine:
+    normalized = engine.lower()
+    if normalized in {"whisper", "openai"}:
+        return WhisperEngine(model=model, device=device)
+    if normalized in {"faster-whisper", "ctranslate2", "faster"}:
+        return FasterWhisperEngine(model=model, device=device)
+    raise ValueError(f"Engine ASR desconhecido: {engine}")
+
+
+def _detect_device(preferred: Optional[str] = None) -> str:
+    if preferred:
+        return preferred
+    try:
+        import torch
+
+        if torch.cuda.is_available():  # pragma: no cover - depends on environment
+            return "cuda"
+    except Exception:  # pragma: no cover - torch optional
+        logger.debug("Torch indisponível para detecção automática de GPU")
+    return "cpu"
+
+
+class WhisperEngine(BaseASREngine):
+    def __init__(self, model: str, device: Optional[str] = None):
+        try:
+            import whisper
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("whisper não está instalado") from exc
+
+        self._whisper = whisper
+        self.model_name = model
+        self.model = whisper.load_model(model, device=_detect_device(device))
+
+    def transcribe(
+        self,
+        audio_path: Path,
+        *,
+        language: Optional[str] = None,
+        vad_segments: Optional[Sequence[VADSegment]] = None,
+        word_timestamps: bool = False,
+    ) -> TranscriptionResult:
+        options = {
+            "language": language,
+            "word_timestamps": word_timestamps,
+            "condition_on_previous_text": False,
+            "task": "transcribe",
+        }
+        logger.info("Iniciando transcrição com Whisper (%s)", self.model.device)
+        result = self.model.transcribe(str(audio_path), **options)
+        segments = _parse_whisper_segments(result, vad_segments)
+        metadata = {
+            "engine": "whisper",
+            "model": self.model_name,
+            "device": str(self.model.device),
+        }
+        return TranscriptionResult(segments=segments, language=result.get("language"), metadata=metadata)
+
+
+def _parse_whisper_segments(result: Dict[str, object], vad_segments: Optional[Sequence[VADSegment]]) -> List[TranscriptionSegment]:
+    segments: List[TranscriptionSegment] = []
+    for seg in result.get("segments", []):  # type: ignore[assignment]
+        start = float(seg["start"])
+        end = float(seg["end"])
+        if vad_segments and not _overlaps_vad(start, end, vad_segments):
+            continue
+        words = [
+            WordMetadata(
+                word=w.get("word", ""),
+                start=w.get("start"),
+                end=w.get("end"),
+                confidence=w.get("probability"),
+            )
+            for w in seg.get("words", [])  # type: ignore[attr-defined]
+        ]
+        confidence = None
+        if seg.get("avg_logprob") is not None:
+            confidence = math.exp(float(seg["avg_logprob"]))
+        segments.append(
+            TranscriptionSegment(
+                start=start,
+                end=end,
+                text=seg.get("text", "").strip(),
+                confidence=confidence,
+                words=words,
+            )
+        )
+    return segments
+
+
+class FasterWhisperEngine(BaseASREngine):
+    def __init__(self, model: str, device: Optional[str] = None):
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("faster-whisper não está instalado") from exc
+
+        device = _detect_device(device)
+        compute_type = "float16" if device == "cuda" else "int8"
+        self.model_path = model
+        self.model = WhisperModel(model, device=device, compute_type=compute_type)
+        self._device = device
+
+    def transcribe(
+        self,
+        audio_path: Path,
+        *,
+        language: Optional[str] = None,
+        vad_segments: Optional[Sequence[VADSegment]] = None,
+        word_timestamps: bool = False,
+    ) -> TranscriptionResult:
+        logger.info("Iniciando transcrição com Faster-Whisper (%s)", self._device)
+        segments_iter, info = self.model.transcribe(
+            str(audio_path),
+            language=language,
+            word_timestamps=word_timestamps,
+        )
+        segments = _parse_faster_whisper_segments(segments_iter, vad_segments)
+        metadata = {
+            "engine": "faster-whisper",
+            "model": self.model_path,
+            "device": self._device,
+            "language_probability": getattr(info, "language_probability", None),
+        }
+        return TranscriptionResult(segments=segments, language=info.language, metadata=metadata)
+
+
+def _parse_faster_whisper_segments(
+    segments_iter: Iterable[object], vad_segments: Optional[Sequence[VADSegment]]
+) -> List[TranscriptionSegment]:
+    segments: List[TranscriptionSegment] = []
+    for segment in segments_iter:
+        start = float(segment.start)
+        end = float(segment.end)
+        if vad_segments and not _overlaps_vad(start, end, vad_segments):
+            continue
+        words = [
+            WordMetadata(
+                word=word.word,
+                start=word.start,
+                end=word.end,
+                confidence=getattr(word, "probability", None),
+            )
+            for word in getattr(segment, "words", []) or []
+        ]
+        confidence_logprob = getattr(segment, "avg_logprob", None)
+        confidence_value = None
+        if isinstance(confidence_logprob, (int, float)):
+            confidence_value = math.exp(confidence_logprob)
+        segments.append(
+            TranscriptionSegment(
+                start=start,
+                end=end,
+                text=str(segment.text).strip(),
+                confidence=confidence_value,
+                words=words,
+            )
+        )
+    return segments
+
+
+def _overlaps_vad(start: float, end: float, vad_segments: Sequence[VADSegment]) -> bool:
+    for vad in vad_segments:
+        if start < vad.end and end > vad.start:
+            return True
+    return False
+
+
+__all__ = [
+    "WordMetadata",
+    "TranscriptionSegment",
+    "TranscriptionResult",
+    "BaseASREngine",
+    "load_asr_engine",
+]

--- a/oratiotranscripta/cli.py
+++ b/oratiotranscripta/cli.py
@@ -1,0 +1,111 @@
+"""Command line interface for OratioTranscripta."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from .aggregation import AggregationConfig, aggregate_segments
+from .alignment import AlignmentConfig, align_transcription
+from .asr import TranscriptionResult, load_asr_engine
+from .diarization import DiarizationConfig, apply_diarization
+from .export import export_transcription
+from .ingest import IngestionConfig, IngestionError, ingest_audio
+from .vad import load_vad_backend
+
+LOG_FORMAT = "[%(levelname)s] %(message)s"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Pipeline completo de transcrição de áudio")
+    parser.add_argument("--source", choices=["local", "youtube"], default="local", help="Origem do áudio")
+    parser.add_argument("--path", type=Path, help="Caminho para arquivo local quando --source=local")
+    parser.add_argument("--url", help="URL do vídeo quando --source=youtube")
+    parser.add_argument("--out", type=Path, default=Path("output"), help="Caminho base para os arquivos de saída")
+    parser.add_argument("--model", default="small", help="Modelo Whisper/Faster-Whisper a ser utilizado")
+    parser.add_argument("--engine", choices=["whisper", "faster-whisper"], default="whisper", help="Backend de ASR")
+    parser.add_argument("--lang", help="Idioma forçado para reconhecimento")
+    parser.add_argument("--device", help="Dispositivo (cpu/cuda)")
+    parser.add_argument("--cookies", type=Path, help="Arquivo de cookies para yt-dlp")
+    parser.add_argument(
+        "--export",
+        nargs="+",
+        default=["txt"],
+        help="Formatos de exportação desejados (txt, srt, vtt, json)",
+    )
+    parser.add_argument("--window", type=float, help="Janela fixa em segundos para agregação de legendas")
+    parser.add_argument("--vad", default="auto", help="Backend de VAD: auto, webrtc, silero, pyannote, none")
+    parser.add_argument("--diarize", choices=["none", "basic", "pyannote"], default="none", help="Modo de diarização")
+    parser.add_argument("--pyannote-token", help="Token de autenticação da HuggingFace para pipelines pyannote")
+    parser.add_argument("--align", action="store_true", help="Habilita alinhamento de palavras com WhisperX")
+    parser.add_argument("--words", action="store_true", help="Exporta metadados de palavras quando suportado")
+    parser.add_argument("--keep-temp", action="store_true", help="Mantém diretórios temporários gerados")
+    parser.add_argument("--verbose", action="store_true", help="Mostra logs detalhados")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format=LOG_FORMAT)
+    logger = logging.getLogger("oratiotranscripta")
+    logger.info("Iniciando pipeline de transcrição")
+
+    ingestion_config = IngestionConfig(
+        source=args.source,
+        path=args.path,
+        url=args.url,
+        cookies=args.cookies,
+        cleanup=not args.keep_temp,
+    )
+
+    try:
+        ingestion_result = ingest_audio(ingestion_config)
+    except IngestionError as exc:
+        parser.error(str(exc))
+        return
+
+    try:
+        vad_kwargs = {}
+        if args.vad == "pyannote":
+            vad_kwargs["auth_token"] = args.pyannote_token
+        vad_backend = load_vad_backend(args.vad, **vad_kwargs)
+        vad_segments = vad_backend(ingestion_result.audio_path)
+        logger.info("VAD gerou %d segmentos", len(vad_segments))
+
+        asr_engine = load_asr_engine(args.engine, args.model, device=args.device)
+        word_timestamps = bool(args.words or args.align)
+        transcription: TranscriptionResult = asr_engine.transcribe(
+            ingestion_result.audio_path,
+            language=args.lang,
+            vad_segments=vad_segments,
+            word_timestamps=word_timestamps,
+        )
+        logger.info("Reconhecimento retornou %d segmentos", len(transcription.segments))
+
+        alignment_config = AlignmentConfig(
+            enabled=args.align,
+            device=args.device,
+            language=args.lang,
+        )
+        transcription = align_transcription(transcription, ingestion_result.audio_path, alignment_config)
+
+        diarization_config = DiarizationConfig(mode=args.diarize, pyannote_token=args.pyannote_token)
+        transcription = apply_diarization(transcription, ingestion_result.audio_path, diarization_config)
+
+        aggregation_config = AggregationConfig(window=args.window)
+        transcription.segments = aggregate_segments(transcription.segments, aggregation_config)
+
+        exported = export_transcription(transcription, args.out, args.export)
+        for path in exported:
+            logger.info("Arquivo exportado: %s", path)
+    finally:
+        if not args.keep_temp:
+            ingestion_result.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/oratiotranscripta/diarization/__init__.py
+++ b/oratiotranscripta/diarization/__init__.py
@@ -1,0 +1,98 @@
+"""Diarization utilities."""
+
+from __future__ import annotations
+
+import audioop
+import logging
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from ..asr import TranscriptionResult, TranscriptionSegment
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiarizationConfig:
+    mode: str = "none"
+    pyannote_token: Optional[str] = None
+
+
+def apply_diarization(
+    result: TranscriptionResult,
+    audio_path: Path,
+    config: DiarizationConfig,
+) -> TranscriptionResult:
+    mode = (config.mode or "none").lower()
+    if mode in {"none", "off"}:
+        return result
+    if mode == "basic":
+        _basic_diarization(result, audio_path)
+        result.metadata["diarization"] = {"mode": "basic"}
+        return result
+    if mode == "pyannote":
+        _pyannote_diarization(result, audio_path, config.pyannote_token)
+        result.metadata["diarization"] = {"mode": "pyannote"}
+        return result
+    raise ValueError(f"Modo de diarização desconhecido: {config.mode}")
+
+
+def _basic_diarization(result: TranscriptionResult, audio_path: Path) -> None:
+    energies = _segment_energies(audio_path, result.segments)
+    speaker_index = 0
+    last_end = None
+    last_energy = None
+    for segment, energy in zip(result.segments, energies):
+        if last_end is not None and segment.start - last_end > 1.5:
+            speaker_index += 1
+        elif last_energy is not None and energy is not None:
+            ratio = abs(energy - last_energy) / max(last_energy, 1e-3)
+            if ratio > 0.3:
+                speaker_index += 1
+        segment.speaker = f"SPK{speaker_index + 1}"
+        last_end = segment.end
+        last_energy = energy
+    logger.debug("Basic diarization assigned %d speaker(s)", speaker_index + 1)
+
+
+def _segment_energies(audio_path: Path, segments: List[TranscriptionSegment]) -> List[float]:
+    energies: List[float] = []
+    with wave.open(str(audio_path), "rb") as wf:
+        sample_rate = wf.getframerate()
+        width = wf.getsampwidth()
+        total_frames = wf.getnframes()
+        for segment in segments:
+            start_frame = min(int(segment.start * sample_rate), total_frames)
+            end_frame = min(int(segment.end * sample_rate), total_frames)
+            wf.setpos(start_frame)
+            frames = wf.readframes(max(end_frame - start_frame, 1))
+            try:
+                rms = audioop.rms(frames, width)
+            except audioop.error:  # pragma: no cover - occurs on malformed data
+                rms = 0
+            energies.append(float(rms))
+    return energies
+
+
+def _pyannote_diarization(result: TranscriptionResult, audio_path: Path, token: Optional[str]) -> None:
+    try:
+        from pyannote.audio import Pipeline  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("pyannote.audio não está instalado") from exc
+
+    pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization", use_auth_token=token)
+    diarization = pipeline(audio_path)
+    for turn, _, speaker in diarization.itertracks(yield_label=True):
+        _assign_speaker(result.segments, turn.start, turn.end, speaker)
+
+
+def _assign_speaker(segments: List[TranscriptionSegment], start: float, end: float, speaker: str) -> None:
+    for segment in segments:
+        overlap = min(segment.end, end) - max(segment.start, start)
+        if overlap > 0:
+            segment.speaker = speaker
+
+
+__all__ = ["DiarizationConfig", "apply_diarization"]

--- a/oratiotranscripta/export/__init__.py
+++ b/oratiotranscripta/export/__init__.py
@@ -1,0 +1,110 @@
+"""Transcription exporters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from ..asr import TranscriptionResult, TranscriptionSegment
+
+
+def export_transcription(
+    result: TranscriptionResult,
+    destination: Path,
+    formats: Iterable[str],
+) -> List[Path]:
+    base_path = Path(destination)
+    if base_path.suffix:
+        base_dir = base_path.parent
+        stem = base_path.stem
+    else:
+        base_dir = base_path
+        stem = base_path.name or "transcript"
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    exported: List[Path] = []
+    for fmt in formats:
+        fmt_lower = fmt.lower()
+        if fmt_lower == "txt":
+            path = base_dir / f"{stem}.txt"
+            _export_txt(result, path)
+        elif fmt_lower == "srt":
+            path = base_dir / f"{stem}.srt"
+            _export_srt(result, path)
+        elif fmt_lower == "vtt":
+            path = base_dir / f"{stem}.vtt"
+            _export_vtt(result, path)
+        elif fmt_lower == "json":
+            path = base_dir / f"{stem}.json"
+            _export_json(result, path)
+        else:
+            raise ValueError(f"Formato de exportação desconhecido: {fmt}")
+        exported.append(path)
+    return exported
+
+
+def _export_txt(result: TranscriptionResult, path: Path) -> None:
+    lines = [f"# language: {result.language or 'unknown'}"]
+    for key, value in sorted(result.metadata.items()):
+        lines.append(f"# {key}: {value}")
+    for segment in result.segments:
+        start = _format_timestamp(segment.start)
+        end = _format_timestamp(segment.end)
+        speaker = f"{segment.speaker}: " if segment.speaker else ""
+        confidence = f" (conf={segment.confidence:.2f})" if segment.confidence is not None else ""
+        lines.append(f"[{start} -> {end}] {speaker}{segment.text}{confidence}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _export_srt(result: TranscriptionResult, path: Path) -> None:
+    lines: List[str] = []
+    for index, segment in enumerate(result.segments, start=1):
+        start = _format_timestamp(segment.start, for_srt=True)
+        end = _format_timestamp(segment.end, for_srt=True)
+        lines.append(str(index))
+        lines.append(f"{start} --> {end}")
+        text = _format_caption_text(segment)
+        lines.append(text)
+        lines.append("")
+    path.write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
+
+
+def _export_vtt(result: TranscriptionResult, path: Path) -> None:
+    lines: List[str] = ["WEBVTT", ""]
+    for segment in result.segments:
+        start = _format_timestamp(segment.start, for_vtt=True)
+        end = _format_timestamp(segment.end, for_vtt=True)
+        lines.append(f"{start} --> {end}")
+        lines.append(_format_caption_text(segment))
+        lines.append("")
+    path.write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
+
+
+def _export_json(result: TranscriptionResult, path: Path) -> None:
+    data = result.to_dict()
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _format_caption_text(segment: TranscriptionSegment) -> str:
+    speaker = f"{segment.speaker}: " if segment.speaker else ""
+    confidence = ""
+    if segment.confidence is not None:
+        confidence = f" (conf={segment.confidence:.2f})"
+    lines = [speaker + segment.text.strip() + confidence]
+    return "\n".join(lines)
+
+
+def _format_timestamp(seconds: float, *, for_srt: bool = False, for_vtt: bool = False) -> str:
+    millis = int(round(seconds * 1000))
+    hours, remainder = divmod(millis, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, millis = divmod(remainder, 1000)
+    if for_srt:
+        return f"{hours:02}:{minutes:02}:{secs:02},{millis:03}"
+    if for_vtt:
+        return f"{hours:02}:{minutes:02}:{secs:02}.{millis:03}"
+    return f"{hours:02}:{minutes:02}:{secs:02}.{millis:03}"
+
+
+__all__ = ["export_transcription"]

--- a/oratiotranscripta/ingest/__init__.py
+++ b/oratiotranscripta/ingest/__init__.py
@@ -1,0 +1,156 @@
+"""Audio ingestion utilities."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IngestionConfig:
+    """Configuration for ingesting audio from a source."""
+
+    source: str = "local"
+    path: Optional[Path] = None
+    url: Optional[str] = None
+    cookies: Optional[Path] = None
+    tmp_root: Optional[Path] = None
+    cleanup: bool = True
+    normalize: bool = True
+    sample_rate: int = 16_000
+    channels: int = 1
+    audio_format: str = "wav"
+
+
+@dataclass
+class IngestionResult:
+    """Result of an ingestion operation."""
+
+    audio_path: Path
+    workdir: Path
+    source_path: Path
+    cleanup_enabled: bool = True
+
+    def cleanup(self) -> None:
+        """Remove temporary artifacts if configured."""
+
+        if not self.cleanup_enabled:
+            return
+        try:
+            shutil.rmtree(self.workdir)
+        except FileNotFoundError:  # pragma: no cover - directory already gone
+            logger.debug("Temporary directory already removed: %s", self.workdir)
+
+
+class IngestionError(RuntimeError):
+    """Raised when the ingestion pipeline fails."""
+
+
+def ingest_audio(config: IngestionConfig) -> IngestionResult:
+    """Download and/or normalise audio according to ``config``."""
+
+    workdir = Path(tempfile.mkdtemp(prefix="oratiotranscripta_", dir=config.tmp_root))
+    logger.debug("Created temporary workdir at %s", workdir)
+
+    try:
+        source_path = _resolve_source(config, workdir)
+        audio_path = _normalise_audio(source_path, workdir, config)
+    except Exception:
+        shutil.rmtree(workdir, ignore_errors=True)
+        raise
+
+    return IngestionResult(
+        audio_path=audio_path,
+        workdir=workdir,
+        source_path=source_path,
+        cleanup_enabled=config.cleanup,
+    )
+
+
+def _resolve_source(config: IngestionConfig, workdir: Path) -> Path:
+    if config.source == "youtube":
+        return _download_from_youtube(config, workdir)
+    if config.source == "local":
+        if not config.path:
+            raise IngestionError("--path is required when --source=local")
+        path = Path(config.path).expanduser().resolve()
+        if not path.exists():
+            raise IngestionError(f"Arquivo local não encontrado: {path}")
+        return path
+    raise IngestionError(f"Fonte de ingestão desconhecida: {config.source}")
+
+
+def _download_from_youtube(config: IngestionConfig, workdir: Path) -> Path:
+    try:
+        from yt_dlp import YoutubeDL
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise IngestionError("yt-dlp não está instalado para downloads do YouTube") from exc
+
+    if not config.url:
+        raise IngestionError("--url é obrigatório para downloads do YouTube")
+
+    ydl_opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(workdir / "%(id)s.%(ext)s"),
+        "noplaylist": True,
+        "quiet": True,
+        "no_warnings": True,
+        "cookiefile": str(config.cookies) if config.cookies else None,
+    }
+    logger.info("Baixando áudio do YouTube de %s", config.url)
+    with YoutubeDL({k: v for k, v in ydl_opts.items() if v is not None}) as ydl:
+        info = ydl.extract_info(config.url, download=True)
+        if "requested_downloads" in info and info["requested_downloads"]:
+            filename = info["requested_downloads"][0]["filepath"]
+            return Path(filename)
+
+    candidates = sorted(workdir.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not candidates:
+        raise IngestionError("Não foi possível determinar o arquivo baixado")
+    return candidates[0]
+
+
+def _normalise_audio(source_path: Path, workdir: Path, config: IngestionConfig) -> Path:
+    if not config.normalize:
+        target = workdir / source_path.name
+        if source_path != target:
+            shutil.copy2(source_path, target)
+            return target
+        return source_path
+
+    output_path = workdir / f"normalised.{config.audio_format}"
+    command = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(source_path),
+        "-ac",
+        str(config.channels),
+        "-ar",
+        str(config.sample_rate),
+        "-vn",
+        str(output_path),
+    ]
+    logger.debug("Normalizando áudio com comando: %s", " ".join(command))
+    try:
+        subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError as exc:  # pragma: no cover - depende do ambiente
+        raise IngestionError("ffmpeg não encontrado no PATH") from exc
+    except subprocess.CalledProcessError as exc:
+        raise IngestionError(f"ffmpeg falhou ao processar o áudio: {exc.stderr.decode(errors='ignore')}")
+    return output_path
+
+
+__all__ = [
+    "IngestionConfig",
+    "IngestionResult",
+    "IngestionError",
+    "ingest_audio",
+]

--- a/oratiotranscripta/vad/__init__.py
+++ b/oratiotranscripta/vad/__init__.py
@@ -1,0 +1,207 @@
+"""Voice activity detection backends."""
+
+from __future__ import annotations
+
+import logging
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VADSegment:
+    """Time span flagged as speech."""
+
+    start: float
+    end: float
+
+
+class BaseVAD:
+    """Base class for VAD backends."""
+
+    def __call__(self, audio_path: Path) -> List[VADSegment]:
+        raise NotImplementedError
+
+
+class BypassVAD(BaseVAD):
+    """Return a single full-length segment."""
+
+    def __call__(self, audio_path: Path) -> List[VADSegment]:
+        duration = _get_duration(audio_path)
+        logger.debug("Bypass VAD returning full duration %.2fs", duration)
+        return [VADSegment(0.0, duration)]
+
+
+class WebRTCVAD(BaseVAD):
+    """VAD based on the WebRTC implementation."""
+
+    def __init__(self, aggressiveness: int = 3, frame_ms: int = 30):
+        try:
+            import webrtcvad  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("webrtcvad não está instalado") from exc
+
+        if not 0 <= aggressiveness <= 3:
+            raise ValueError("aggressiveness deve estar entre 0 e 3")
+        self._vad = webrtcvad.Vad(aggressiveness)
+        self.frame_ms = frame_ms
+
+    def __call__(self, audio_path: Path) -> List[VADSegment]:
+        with wave.open(str(audio_path), "rb") as wf:
+            sample_rate = wf.getframerate()
+            channels = wf.getnchannels()
+            sampwidth = wf.getsampwidth()
+            if channels != 1 or sampwidth != 2:
+                raise RuntimeError("VAD WebRTC requer áudio PCM mono de 16 bits")
+            frame_size = int(sample_rate * self.frame_ms / 1000)
+            bytes_per_frame = frame_size * sampwidth
+            timestamp = 0.0
+            triggered = False
+            segments: List[VADSegment] = []
+            current_start: Optional[float] = None
+
+            while True:
+                frames = wf.readframes(frame_size)
+                if len(frames) < bytes_per_frame:
+                    break
+                is_speech = self._vad.is_speech(frames, sample_rate)
+                if is_speech and not triggered:
+                    triggered = True
+                    current_start = timestamp
+                elif not is_speech and triggered:
+                    triggered = False
+                    if current_start is not None:
+                        segments.append(VADSegment(current_start, timestamp))
+                        current_start = None
+                timestamp += self.frame_ms / 1000.0
+
+            if triggered and current_start is not None:
+                duration = _get_duration(audio_path)
+                segments.append(VADSegment(current_start, duration))
+
+        merged = _merge_close_segments(segments, gap=0.3)
+        logger.debug("WebRTC VAD produced %d segments", len(merged))
+        return merged
+
+
+class SileroVAD(BaseVAD):
+    """Silero VAD via torch hub."""
+
+    def __init__(self, device: Optional[str] = None):
+        try:
+            import torch
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("torch é necessário para o VAD Silero") from exc
+
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = device
+        try:
+            self.model, utils = torch.hub.load(
+                repo_or_dir="snakers4/silero-vad",
+                model="silero_vad",
+                force_reload=False,
+            )
+        except Exception as exc:  # pragma: no cover - heavy optional dependency
+            raise RuntimeError("Falha ao carregar modelo Silero VAD") from exc
+        (
+            self.get_speech_timestamps,
+            self.save_audio,
+            self.read_audio,
+            self.vad_iterator,
+            self.collect_chunks,
+        ) = utils
+
+    def __call__(self, audio_path: Path) -> List[VADSegment]:
+        wav = self.read_audio(str(audio_path), sampling_rate=16_000)
+        speeches = self.collect_chunks(
+            self.model,
+            wav,
+            sampling_rate=16_000,
+            threshold=0.5,
+            min_speech_duration_ms=250,
+            max_speech_duration_s=15,
+            min_silence_duration_ms=100,
+            speech_pad_ms=120,
+            device=self.device,
+        )
+        segments = [VADSegment(s[0] / 1000.0, s[1] / 1000.0) for s in speeches]
+        logger.debug("Silero VAD produced %d segments", len(segments))
+        return segments
+
+
+class PyannoteVAD(BaseVAD):
+    """pyannote.audio VAD pipeline."""
+
+    def __init__(self, auth_token: Optional[str] = None):
+        try:
+            from pyannote.audio import Pipeline  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("pyannote.audio não está instalado") from exc
+
+        self.pipeline = Pipeline.from_pretrained(
+            "pyannote/voice-activity-detection",
+            use_auth_token=auth_token,
+        )
+
+    def __call__(self, audio_path: Path) -> List[VADSegment]:
+        vad_result = self.pipeline(audio_path)
+        segments = [VADSegment(segment.start, segment.end) for segment in vad_result.get_timeline()]
+        logger.debug("pyannote VAD produced %d segments", len(segments))
+        return segments
+
+
+def load_vad_backend(name: str, **kwargs) -> BaseVAD:
+    """Factory for VAD backends."""
+
+    normalized = (name or "none").lower()
+    if normalized in {"none", "off", "disable", "disabled"}:
+        return BypassVAD()
+    if normalized in {"auto", "default"}:
+        try:
+            return WebRTCVAD()
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Falha ao inicializar WebRTC VAD: %s", exc)
+            return BypassVAD()
+    if normalized == "webrtc":
+        return WebRTCVAD(**kwargs)
+    if normalized == "silero":
+        return SileroVAD(**kwargs)
+    if normalized == "pyannote":
+        return PyannoteVAD(**kwargs)
+    raise ValueError(f"Backend de VAD desconhecido: {name}")
+
+
+def _get_duration(audio_path: Path) -> float:
+    with wave.open(str(audio_path), "rb") as wf:
+        frames = wf.getnframes()
+        sample_rate = wf.getframerate()
+    return frames / float(sample_rate)
+
+
+def _merge_close_segments(segments: Iterable[VADSegment], gap: float = 0.2) -> List[VADSegment]:
+    merged: List[VADSegment] = []
+    for segment in sorted(segments, key=lambda s: s.start):
+        if not merged:
+            merged.append(segment)
+            continue
+        last = merged[-1]
+        if segment.start - last.end <= gap:
+            merged[-1] = VADSegment(last.start, max(last.end, segment.end))
+        else:
+            merged.append(segment)
+    return merged
+
+
+__all__ = [
+    "VADSegment",
+    "BaseVAD",
+    "BypassVAD",
+    "WebRTCVAD",
+    "SileroVAD",
+    "PyannoteVAD",
+    "load_vad_backend",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oratiotranscripta"
+version = "0.1.0"
+description = "Pipeline modular para transcrição, alinhamento e exportação de áudio."
+readme = "README.md"
+authors = [{ name = "OratioTranscripta" }]
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+  "yt-dlp>=2023.10.13",
+  "webrtcvad>=2.0.10",
+]
+
+[project.optional-dependencies]
+asr = [
+  "openai-whisper>=20230314",
+]
+faster = [
+  "faster-whisper>=0.9.0",
+]
+alignment = [
+  "whisperx>=3.1",
+]
+diarization = [
+  "pyannote.audio>=3.0.1",
+]
+silero = [
+  "torch>=2.0.0",
+  "torchaudio>=2.0.0",
+]
+all = [
+  "openai-whisper>=20230314",
+  "faster-whisper>=0.9.0",
+  "whisperx>=3.1",
+  "pyannote.audio>=3.0.1",
+  "torch>=2.0.0",
+  "torchaudio>=2.0.0",
+]
+
+[project.scripts]
+oratiotranscripta = "oratiotranscripta.cli:main"


### PR DESCRIPTION
## Summary
- add a modular `oratiotranscripta` package with ingestion, VAD, ASR, alignment, diarization, aggregation, and export layers
- provide an argparse-based CLI and Python entry-point to drive the full pipeline and optional alignment/diarization features
- document installation and usage while declaring base and optional dependencies in `pyproject.toml`

## Testing
- python -m oratiotranscripta --help

------
https://chatgpt.com/codex/tasks/task_e_68df145da9dc8330895e5be49ea28852