### PR TITLE
Set torch hub trust flag for Silero VAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ O **Oratio Transcripta** é uma proposta de valorização da palavra, da histór
 
 - **Ingestão flexível**: suporte a arquivos locais ou YouTube (`yt-dlp`) com normalização automática de áudio via `ffmpeg`.
 - **Detecção de voz (VAD)**: backends selecionáveis (`webrtc`, `silero`, `pyannote`) com possibilidade de bypass.
+  - O backend Silero é carregado via `torch.hub` com `trust_repo=True` para evitar prompts interativos sobre confiança no repositório oficial do modelo.
 - **Reconhecimento de fala (ASR)**: escolha entre Whisper oficial ou Faster-Whisper (CTranslate2) com seleção automática de CPU/GPU.
 - **Alinhamento opcional**: integração com WhisperX para produzir timestamps de palavras de alta precisão.
 - **Diarização**: heurísticas básicas de energia/pausa ou pipeline pré-treinado do `pyannote.audio` (requer token HF).

--- a/oratiotranscripta/vad/__init__.py
+++ b/oratiotranscripta/vad/__init__.py
@@ -104,6 +104,7 @@ class SileroVAD(BaseVAD):
                 repo_or_dir="snakers4/silero-vad",
                 model="silero_vad",
                 force_reload=False,
+                trust_repo=True,
             )
         except Exception as exc:  # pragma: no cover - heavy optional dependency
             raise RuntimeError("Falha ao carregar modelo Silero VAD") from exc


### PR DESCRIPTION
## Summary
- ensure the Silero VAD torch hub loader passes trust_repo to avoid interactive trust prompts
- document in the README why the flag is set on the Silero backend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15f30559c8330b3c9783c17d6922f