### PR TITLE
Handle torch hub TypeError fallback

### DIFF
--- a/oratiotranscripta/vad/__init__.py
+++ b/oratiotranscripta/vad/__init__.py
@@ -101,12 +101,19 @@ class SileroVAD(BaseVAD):
             device = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = device
         try:
-            self.model, utils = torch.hub.load(
-                repo_or_dir="snakers4/silero-vad",
-                model="silero_vad",
-                force_reload=False,
-                trust_repo=True,
-            )
+            try:
+                self.model, utils = torch.hub.load(
+                    repo_or_dir="snakers4/silero-vad",
+                    model="silero_vad",
+                    force_reload=False,
+                    trust_repo=True,
+                )
+            except TypeError:
+                self.model, utils = torch.hub.load(
+                    repo_or_dir="snakers4/silero-vad",
+                    model="silero_vad",
+                    force_reload=False,
+                )
         except Exception as exc:  # pragma: no cover - heavy optional dependency
             raise RuntimeError("Falha ao carregar modelo Silero VAD") from exc
         (


### PR DESCRIPTION
## Summary
- retry loading the Silero VAD model without the `trust_repo` flag when torch hub raises a TypeError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e165fd4f748330bbbfd82cd7e62da3