### PR TITLE
Add Silero VAD fallback to get_speech_timestamps

### DIFF
--- a/oratiotranscripta/vad/__init__.py
+++ b/oratiotranscripta/vad/__init__.py
@@ -138,11 +138,24 @@ class SileroVAD(BaseVAD):
         if "threshold" in inspect.signature(self.collect_chunks).parameters:
             collect_kwargs["threshold"] = 0.5
 
-        speeches = self.collect_chunks(
-            self.model,
-            wav,
-            **collect_kwargs,
-        )
+        try:
+            speeches = self.collect_chunks(
+                self.model,
+                wav,
+                **collect_kwargs,
+            )
+        except Exception:
+            ts_params = inspect.signature(self.get_speech_timestamps).parameters
+            ts_kwargs = {
+                key: value
+                for key, value in collect_kwargs.items()
+                if key in ts_params
+            }
+            speeches = self.get_speech_timestamps(
+                wav,
+                self.model,
+                **ts_kwargs,
+            )
         segments = [VADSegment(s[0] / 1000.0, s[1] / 1000.0) for s in speeches]
         logger.debug("Silero VAD produced %d segments", len(segments))
         return segments


### PR DESCRIPTION
## Summary
- wrap the Silero collect_chunks invocation in a try/except
- fall back to get_speech_timestamps with the supported keyword arguments when collect_chunks fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e16662237c83308ca02101898755f3