### PR TITLE
Filter collect_chunks kwargs for Silero VAD

### DIFF
--- a/oratiotranscripta/vad/__init__.py
+++ b/oratiotranscripta/vad/__init__.py
@@ -143,14 +143,23 @@ class SileroVAD(BaseVAD):
             "device": self.device,
         }
 
-        if "threshold" in inspect.signature(self.collect_chunks).parameters:
+        collect_signature = inspect.signature(self.collect_chunks)
+        collect_params = collect_signature.parameters
+
+        if "threshold" in collect_params:
             collect_kwargs["threshold"] = 0.5
+
+        ckw = {
+            key: value
+            for key, value in collect_kwargs.items()
+            if key in collect_params
+        }
 
         try:
             speeches = self.collect_chunks(
                 self.model,
                 wav,
-                **collect_kwargs,
+                **ckw,
             )
         except Exception:
             ts_params = inspect.signature(self.get_speech_timestamps).parameters


### PR DESCRIPTION
## Summary
- inspect the Silero `collect_chunks` function signature to detect supported keyword arguments
- filter the configured keyword dictionary to only pass supported keys to `collect_chunks`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e16e020ed08330a49f619e6390c7dd