### PR TITLE
Log collect_chunks fallback error

### DIFF
--- a/oratiotranscripta/vad/__init__.py
+++ b/oratiotranscripta/vad/__init__.py
@@ -161,7 +161,11 @@ class SileroVAD(BaseVAD):
                 wav,
                 **ckw,
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "Silero collect_chunks falhou; usando get_speech_timestamps como fallback: %s",
+                exc,
+            )
             ts_params = inspect.signature(self.get_speech_timestamps).parameters
             ts_kwargs = {
                 key: value


### PR DESCRIPTION
## Summary
- capture exceptions raised by `collect_chunks` in the Silero VAD backend
- log a warning when falling back to `get_speech_timestamps`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1701076388330a67f11a22c08848e