### PR TITLE
Add pyannote optional extra and document optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ O **Oratio Transcripta** é uma proposta de valorização da palavra, da histór
 pip install .[all]  # instala o pacote e todas as dependências opcionais
 ```
 
-Para instalações mínimas use apenas o conjunto de extras necessário, por exemplo `pip install .[asr]`.
+Os extras disponíveis permitem instalar apenas os componentes necessários:
+
+| Extra | Dependências principais | Quando usar |
+|-------|-------------------------|-------------|
+| `asr` | `openai-whisper>=20230314` | Transcrição com Whisper oficial. |
+| `faster` | `faster-whisper>=0.9.0` | Transcrição com Faster-Whisper (CTranslate2). |
+| `alignment` | `whisperx>=3.1` | Alinhamento de palavras com WhisperX. |
+| `diarization` | `pyannote.audio>=3.3`, `speechbrain>=1.0.0`, `matplotlib>=3.10,<3.11` | Pipeline pyannote para diarização/VAD. |
+| `pyannote` | `pyannote.audio>=3.3`, `speechbrain>=1.0.0`, `matplotlib>=3.10,<3.11` | Instalação dedicada às funcionalidades pyannote (VAD/diarização). |
+| `silero` | `torch>=2.0.0`, `torchaudio>=2.0.0` | VAD com Silero. |
+| `all` | União explícita de todos os extras acima | Instalação completa com todos os backends opcionais. |
+
+Para instalações mínimas escolha apenas os extras necessários, por exemplo `pip install .[asr]` ou `pip install .[pyannote]`.
 
 Certifique-se de ter `ffmpeg` disponível no PATH para normalização e extração de áudio.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,14 @@ alignment = [
   "whisperx>=3.1",
 ]
 diarization = [
-  "pyannote.audio>=3.0.1",
+  "pyannote.audio>=3.3",
+  "speechbrain>=1.0.0",
+  "matplotlib>=3.10,<3.11",
+]
+pyannote = [
+  "pyannote.audio>=3.3",
+  "speechbrain>=1.0.0",
+  "matplotlib>=3.10,<3.11",
 ]
 silero = [
   "torch>=2.0.0",
@@ -36,7 +43,9 @@ all = [
   "openai-whisper>=20230314",
   "faster-whisper>=0.9.0",
   "whisperx>=3.1",
-  "pyannote.audio>=3.0.1",
+  "pyannote.audio>=3.3",
+  "speechbrain>=1.0.0",
+  "matplotlib>=3.10,<3.11",
   "torch>=2.0.0",
   "torchaudio>=2.0.0",
 ]


### PR DESCRIPTION
## Summary
- add a dedicated pyannote extra with the full runtime dependency chain for diarization/VAD
- expand the diarization and all extras to include the full pyannote dependency set
- document all available extras, including the new pyannote bundle, in the README installation instructions

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1e761b51c8330aa6a18e01f4d4c99