### PR TITLE
Restrict package discovery to oratiotranscripta module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,7 @@ all = [
 
 [project.scripts]
 oratiotranscripta = "oratiotranscripta.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["oratiotranscripta*"]
+exclude = ["saidas*", "tests*", "docs*", "examples*", "scripts*"]


### PR DESCRIPTION
## Summary
- add setuptools package discovery configuration so only the oratiotranscripta package is included in distributions

## Testing
- ⚠️ `python -m pip wheel . --no-build-isolation` *(fails: cannot download setuptools>=61 because the environment blocks outbound network access)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ea2b752083309f0f4b79d7fce2fe