### PR TITLE
Add raw JSON export and enriched metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ O **Oratio Transcripta** é uma proposta de valorização da palavra, da histór
 - **Diarização**: heurísticas básicas de energia/pausa ou pipeline pré-treinado do `pyannote.audio` (requer token HF).
 - **Agregação flexível**: preserva segmentos originais ou gera blocos temporais fixos (`--window`) adequados para legendas.
 - **Exportação rica**: gera `.txt`, `.srt`, `.vtt` e `.json` com metadados de speakers, confidences e timestamps.
+  - O Estágio A do pipeline agora também grava um arquivo `<stem>.raw.json` contendo os segmentos originais antes da agregação (`aggregate_segments`).
+  - O campo `metadata` dos JSONs agrega informações sobre a execução (`pipeline`), artefatos de ingestão (`ingestion`) e versão do software (`software`).
 
 ## Perfis de uso recomendados
 

--- a/oratiotranscripta/export/__init__.py
+++ b/oratiotranscripta/export/__init__.py
@@ -44,6 +44,15 @@ def export_transcription(
     return exported
 
 
+def export_json_file(result: TranscriptionResult, path: Path) -> Path:
+    """Export ``result`` to ``path`` as JSON."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _export_json(result, target)
+    return target
+
+
 def _export_txt(result: TranscriptionResult, path: Path) -> None:
     lines = [f"# language: {result.language or 'unknown'}"]
     for key, value in sorted(result.metadata.items()):
@@ -107,4 +116,4 @@ def _format_timestamp(seconds: float, *, for_srt: bool = False, for_vtt: bool = 
     return f"{hours:02}:{minutes:02}:{secs:02}.{millis:03}"
 
 
-__all__ = ["export_transcription"]
+__all__ = ["export_transcription", "export_json_file"]


### PR DESCRIPTION
## Summary
- store an unaggregated transcription copy before segment aggregation and enrich metadata with pipeline, ingestion, and software details
- export a raw JSON file alongside aggregated outputs and provide a helper for writing standalone JSON transcriptions
- document the new Stage A raw JSON artifact and expanded metadata fields in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e56f7fe818833083e1e949e056da94