### PR TITLE
Enhance annotate exports with structured manifest

### DIFF
--- a/oratiotranscripta/annotate/jsonl.py
+++ b/oratiotranscripta/annotate/jsonl.py
@@ -1,0 +1,76 @@
+"""Helpers for generating JSONL exports with stable identifiers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, Mapping, MutableMapping, Optional, Sequence
+
+
+def _normalise_segment(segment: Mapping[str, Any]) -> Dict[str, Any]:
+    if isinstance(segment, MutableMapping):
+        return dict(segment)
+    return {"text": str(segment)}
+
+
+def _sort_key(item: Dict[str, Any]) -> tuple:
+    start = item.get("start")
+    if isinstance(start, (int, float)):
+        return (0, float(start), item["_source_index"])
+    return (1, item["_source_index"])
+
+
+def iter_records(
+    segments: Sequence[Mapping[str, Any]],
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    raw_transcription: Optional[Mapping[str, Any]] = None,
+) -> Iterator[Dict[str, Any]]:
+    """Yield JSONL records ordered by time with stable IDs."""
+
+    normalised: List[Dict[str, Any]] = []
+    for index, segment in enumerate(segments, start=1):
+        payload = _normalise_segment(segment)
+        payload["_source_index"] = index
+        normalised.append(payload)
+
+    normalised.sort(key=_sort_key)
+
+    base: Dict[str, Any] = {}
+    if metadata is not None:
+        base["metadata"] = dict(metadata)
+    if raw_transcription is not None:
+        base["raw_transcription"] = dict(raw_transcription)
+
+    for position, segment in enumerate(normalised, start=1):
+        record = dict(base)
+        record.update(
+            {
+                "id": f"utt-{position:04d}",
+                "segment_index": segment.pop("_source_index"),
+                "segment": segment,
+            }
+        )
+        record.setdefault("start", segment.get("start"))
+        record.setdefault("end", segment.get("end"))
+        record.setdefault("speaker", segment.get("speaker", ""))
+        yield record
+
+
+def build_records(
+    segments: Sequence[Mapping[str, Any]],
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+    raw_transcription: Optional[Mapping[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Return a list with all JSONL records."""
+
+    return list(
+        iter_records(
+            segments,
+            metadata=metadata,
+            raw_transcription=raw_transcription,
+        )
+    )
+
+
+__all__ = ["build_records", "iter_records"]
+

--- a/oratiotranscripta/annotate/manifest.py
+++ b/oratiotranscripta/annotate/manifest.py
@@ -1,0 +1,109 @@
+"""Utilities for building structured export manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from .metadata import DatasetMetadata
+
+
+def _sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _describe_file(path: Optional[Path]) -> Optional[Dict[str, Any]]:
+    if path is None or not path.exists():
+        return None
+    stat = path.stat()
+    return {
+        "path": str(path),
+        "sha256": _sha256_of(path),
+        "size": stat.st_size,
+    }
+
+
+def build_normalised_metadata(
+    metadata: DatasetMetadata,
+    *,
+    metrics: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    payload = metadata.to_dict()
+    payload["dates"] = sorted(payload.get("dates", []))
+    payload["participant_count"] = len(metadata.participants)
+    payload["participants"] = sorted(
+        (dict(participant.to_dict()) for participant in metadata.participants),
+        key=lambda item: item.get("name", ""),
+    )
+    if metrics:
+        payload.setdefault("statistics", {}).update(dict(metrics))
+    return payload
+
+
+def build_manifest(
+    *,
+    metadata: Optional[DatasetMetadata],
+    metrics: Mapping[str, Any],
+    tei_path: Optional[Path],
+    jsonl_path: Optional[Path],
+    metadata_path: Optional[Path],
+    raw_path: Optional[Path],
+    pipeline: Optional[Mapping[str, Any]] = None,
+    editing: Optional[Mapping[str, Any]] = None,
+    checks: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    manifest: Dict[str, Any] = {
+        "dataset": {},
+        "files": {},
+        "pipeline": dict(pipeline or {}),
+        "editing": dict(editing or {}),
+        "checks": dict(checks or {}),
+    }
+
+    if metadata is not None:
+        manifest["dataset"]["metadata"] = build_normalised_metadata(
+            metadata, metrics=metrics
+        )
+    if metrics:
+        manifest["dataset"].setdefault("metrics", {}).update(dict(metrics))
+
+    files_section: Dict[str, Any] = {}
+    file_entries = {
+        "tei": _describe_file(tei_path),
+        "jsonl": _describe_file(jsonl_path),
+        "metadata": _describe_file(metadata_path),
+        "raw": _describe_file(raw_path),
+    }
+    for key, description in file_entries.items():
+        if description:
+            files_section[key] = description
+    manifest["files"] = files_section
+
+    return manifest
+
+
+def write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(manifest, ensure_ascii=False, indent=2)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+def write_metadata_yaml(path: Path, metadata: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(metadata, ensure_ascii=False, indent=2)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+__all__ = [
+    "build_manifest",
+    "build_normalised_metadata",
+    "write_manifest",
+    "write_metadata_yaml",
+]
+

--- a/tests/test_annotate_jsonl.py
+++ b/tests/test_annotate_jsonl.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oratiotranscripta.annotate.jsonl import build_records
+
+
+def test_build_records_orders_segments_and_adds_ids():
+    segments = [
+        {"start": 5.0, "text": "later", "speaker": "B"},
+        {"start": 2.0, "text": "early", "speaker": "A"},
+        {"text": "no timing"},
+    ]
+
+    records = build_records(
+        segments,
+        metadata={"project": "X"},
+        raw_transcription={"segments": []},
+    )
+
+    assert [record["id"] for record in records] == ["utt-0001", "utt-0002", "utt-0003"]
+    assert [record["segment_index"] for record in records] == [2, 1, 3]
+    assert [record["segment"]["text"] for record in records] == [
+        "early",
+        "later",
+        "no timing",
+    ]
+    assert records[0]["metadata"]["project"] == "X"
+    assert "raw_transcription" in records[0]

--- a/tests/test_annotate_manifest.py
+++ b/tests/test_annotate_manifest.py
@@ -1,0 +1,91 @@
+import hashlib
+import json
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from oratiotranscripta.annotate.manifest import (
+    build_manifest,
+    build_normalised_metadata,
+    write_manifest,
+    write_metadata_yaml,
+)
+from oratiotranscripta.annotate.metadata import DatasetMetadata, Participant
+
+
+def _make_metadata() -> DatasetMetadata:
+    return DatasetMetadata(
+        project="Coleção Teste",
+        event="Sessão Zero",
+        participants=[
+            Participant(name="Bruno", role="convidado"),
+            Participant(name="Ana", role="mediadora", aliases=["A."]),
+        ],
+        dates=["2024-03-01", "2024-02-28"],
+        coverage={"location": "Online"},
+        license="CC-BY-4.0",
+        editors=["Equipe"],
+    )
+
+
+def test_build_manifest_and_metadata_bundle(tmp_path):
+    metadata = _make_metadata()
+    metrics = {"segment_count": 2, "duration_seconds": 3.5}
+
+    tei_path = tmp_path / "transcript.tei.xml"
+    tei_path.write_text("<TEI></TEI>", encoding="utf-8")
+
+    jsonl_path = tmp_path / "transcript.jsonl"
+    jsonl_path.write_text("{}\n", encoding="utf-8")
+
+    raw_path = tmp_path / "raw.json"
+    raw_path.write_text("{}", encoding="utf-8")
+
+    metadata_payload = build_normalised_metadata(metadata, metrics=metrics)
+    metadata_file = tmp_path / "metadata.yml"
+    write_metadata_yaml(metadata_file, metadata_payload)
+
+    manifest = build_manifest(
+        metadata=metadata,
+        metrics=metrics,
+        tei_path=tei_path,
+        jsonl_path=jsonl_path,
+        metadata_path=metadata_file,
+        raw_path=raw_path,
+        pipeline={"step": "annotate", "format": "jsonl"},
+        editing={"editors": metadata.editors},
+        checks={"status": "ok"},
+    )
+
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(manifest_path, manifest)
+
+    written_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert set(written_manifest) == {"dataset", "files", "pipeline", "editing", "checks"}
+    assert "metadata" in written_manifest["dataset"]
+    assert written_manifest["dataset"]["metadata"]["participant_count"] == 2
+    assert written_manifest["dataset"]["metadata"]["participants"][0]["name"] == "Ana"
+    assert written_manifest["dataset"]["metrics"] == metrics
+
+    files = written_manifest["files"]
+    for key in ("tei", "jsonl", "metadata", "raw"):
+        assert key in files
+        described = files[key]
+        expected_path = {
+            "tei": tei_path,
+            "jsonl": jsonl_path,
+            "metadata": metadata_file,
+            "raw": raw_path,
+        }[key]
+        assert described["path"] == str(expected_path)
+        assert described["size"] == expected_path.stat().st_size
+        expected_hash = hashlib.sha256(expected_path.read_bytes()).hexdigest()
+        assert described["sha256"] == expected_hash
+
+    loaded_metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+    assert loaded_metadata["participant_count"] == 2
+    assert loaded_metadata["statistics"]["duration_seconds"] == 3.5
+    assert loaded_metadata["dates"] == ["2024-02-28", "2024-03-01"]


### PR DESCRIPTION
## Summary
- add helpers to build ordered JSONL exports with stable utterance IDs
- generate structured export manifests and normalised metadata bundles
- update annotate CLI to write curated metadata and manifests
- cover manifest and JSONL generation with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58e59e7088330bb9dadc39a4c34b7