### PR TITLE
Add run-level outputs and provenance manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ O **Oratio Transcripta** é uma proposta de valorização da palavra, da histór
 - **Diarização**: heurísticas básicas de energia/pausa ou pipeline pré-treinado do `pyannote.audio` (requer token HF).
 - **Agregação flexível**: preserva segmentos originais ou gera blocos temporais fixos (`--window`) adequados para legendas.
 - **Exportação**: gera `.txt`, `.srt`, `.vtt` e `.json` com metadados de locutores, grau de confiança e carimbos de data/hora.
-  - O Estágio A do pipeline também grava um arquivo `<stem>.raw.json` contendo os segmentos originais antes da agregação (`aggregate_segments`).
+  - Cada execução cria um diretório isolado `output/<run_id>/` contendo os arquivos solicitados, além de uma cópia `<stem>.raw.json` com os segmentos originais antes da agregação (`aggregate_segments`).
+  - Flags opcionais permitem exportar metadados detalhados em JSONL: `--export-json-raw` grava `<stem>.raw_segments.jsonl` e `--export-json-words` registra `<stem>.raw_words.jsonl` (quando timestamps de palavras estiverem disponíveis).
   - O campo `metadata` dos JSONs agrega informações sobre a execução (`pipeline`), artefatos de ingestão (`ingestion`) e versão do software (`software`).
+  - Use `--manifest` para gerar um `run_manifest.json` com proveniência (configurações, hashes de arquivos, ambiente e commit Git) e acesse os logs estruturados em `logs/pipeline.log` dentro do diretório da execução.
 
 ## Perfis de uso recomendados
 
@@ -96,6 +98,10 @@ Opções principais:
 | `--words` | Solicita metadados de palavras quando suportado pelo modelo ASR. |
 | `--keep-temp` | Mantém diretórios temporários gerados. |
 | `--verbose` | Ativa logs detalhados. |
+| `--run-id ID` | Define o identificador do processamento (timestamp UTC por padrão). |
+| `--export-json-raw` | Exporta segmentos brutos pré-agregação em JSONL. |
+| `--export-json-words` | Exporta palavras reconhecidas em JSONL (quando disponíveis). |
+| `--manifest` | Grava `run_manifest.json` com proveniência, hashes e ambiente. |
 
 ### Exemplo
 

--- a/oratiotranscripta/export/jsonl.py
+++ b/oratiotranscripta/export/jsonl.py
@@ -1,0 +1,104 @@
+"""Helpers to export transcription artefacts as JSONL."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional, Sequence
+
+from ..asr import TranscriptionSegment
+
+
+def _prepare_common_metadata(metadata: Mapping[str, object]) -> MutableMapping[str, object]:
+    pipeline = metadata.get("pipeline", {}) if isinstance(metadata, Mapping) else {}
+    ingestion = metadata.get("ingestion", {}) if isinstance(metadata, Mapping) else {}
+
+    def _from_mapping(data: object, key: str) -> Optional[object]:
+        if isinstance(data, Mapping):
+            return data.get(key)
+        return None
+
+    common: MutableMapping[str, object] = {
+        "engine": metadata.get("engine"),
+        "run_id": _from_mapping(pipeline, "run_id"),
+        "source": _from_mapping(pipeline, "source"),
+        "source_path": _from_mapping(ingestion, "source_path"),
+        "audio_path": _from_mapping(ingestion, "audio_path"),
+        "output_dir": _from_mapping(pipeline, "output_dir"),
+    }
+    return common
+
+
+def write_raw_segments_jsonl(
+    path: Path,
+    segments: Sequence[TranscriptionSegment],
+    *,
+    metadata: Mapping[str, object],
+    language: Optional[str],
+) -> Path:
+    """Persista ``segments`` como um arquivo JSONL."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    common = _prepare_common_metadata(metadata)
+
+    with target.open("w", encoding="utf-8") as fh:
+        for index, segment in enumerate(segments):
+            record = {
+                "segment_id": index,
+                "start_sec": segment.start,
+                "end_sec": segment.end,
+                "duration_sec": max(segment.end - segment.start, 0.0),
+                "text": segment.text,
+                "confidence": segment.confidence,
+                "speaker": segment.speaker,
+                "language": language,
+            }
+            record.update(common)
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return target
+
+
+def write_raw_words_jsonl(
+    path: Path,
+    segments: Sequence[TranscriptionSegment],
+    *,
+    metadata: Mapping[str, object],
+    language: Optional[str],
+) -> Optional[Path]:
+    """Persista palavras reconhecidas como JSONL.
+
+    Retorna ``None`` quando não houver palavras a exportar.
+    """
+
+    target = Path(path)
+    has_words = any(segment.words for segment in segments)
+    if not has_words:
+        return None
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    common = _prepare_common_metadata(metadata)
+
+    with target.open("w", encoding="utf-8") as fh:
+        for segment_id, segment in enumerate(segments):
+            for word_id, word in enumerate(segment.words):
+                record = {
+                    "segment_id": segment_id,
+                    "word_id": word_id,
+                    "word": word.word,
+                    "start_sec": word.start,
+                    "end_sec": word.end,
+                    "duration_sec": (word.end - word.start) if None not in (word.start, word.end) else None,
+                    "confidence": word.confidence,
+                    "speaker": segment.speaker,
+                    "language": language,
+                }
+                record.update(common)
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return target
+
+
+__all__ = ["write_raw_segments_jsonl", "write_raw_words_jsonl"]

--- a/oratiotranscripta/provenance.py
+++ b/oratiotranscripta/provenance.py
@@ -1,0 +1,131 @@
+"""Utilities for collecting provenance for a transcription run."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Optional, Sequence
+
+
+def _compute_sha256(path: Path) -> Optional[str]:
+    try:
+        with path.open("rb") as fh:
+            hasher = hashlib.sha256()
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                hasher.update(chunk)
+    except OSError:
+        return None
+    return hasher.hexdigest()
+
+
+def _collect_environment() -> Mapping[str, str]:
+    return {
+        "python_version": sys.version,
+        "platform": platform.platform(),
+        "executable": sys.executable,
+        "cwd": os.getcwd(),
+    }
+
+
+def _collect_git_metadata() -> Optional[Mapping[str, object]]:
+    repo_dir = Path(__file__).resolve().parent
+    try:
+        commit = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_dir, text=True)
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    try:
+        status = (
+            subprocess.check_output(["git", "status", "--short"], cwd=repo_dir, text=True)
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        status = ""
+
+    return {"commit": commit, "dirty": bool(status)}
+
+
+def _normalise_path(path: Path, base: Path) -> str:
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return str(path)
+
+
+def _describe_artifacts(paths: Iterable[Path], base: Path) -> Sequence[Mapping[str, object]]:
+    artifacts: list[Mapping[str, object]] = []
+    for item in paths:
+        candidate = Path(item)
+        if not candidate.exists():
+            artifacts.append({"path": _normalise_path(candidate, base), "exists": False})
+            continue
+        artifacts.append(
+            {
+                "path": _normalise_path(candidate, base),
+                "exists": True,
+                "sha256": _compute_sha256(candidate),
+                "size_bytes": candidate.stat().st_size,
+            }
+        )
+    return artifacts
+
+
+def write_run_manifest(
+    out_dir: Path,
+    *,
+    run_id: str,
+    pipeline: Mapping[str, object],
+    ingestion: Mapping[str, object],
+    software: Mapping[str, object],
+    artifacts: Sequence[Path],
+    log_files: Sequence[Path] | None = None,
+) -> Path:
+    """Write a ``run_manifest.json`` file describing the execution provenance."""
+
+    destination_dir = Path(out_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest: MutableMapping[str, object] = {
+        "run_id": run_id,
+        "pipeline": dict(pipeline),
+        "ingestion": dict(ingestion),
+        "software": dict(software),
+        "environment": dict(_collect_environment()),
+    }
+
+    git_info = _collect_git_metadata()
+    if git_info:
+        manifest["source_control"] = git_info
+
+    artifact_entries = _describe_artifacts(artifacts, destination_dir)
+    manifest["artifacts"] = artifact_entries
+
+    if log_files:
+        manifest["logs"] = _describe_artifacts(log_files, destination_dir)
+
+    hashes: MutableMapping[str, object] = {}
+    for key in ("audio_path", "source_path"):
+        raw_path = ingestion.get(key)
+        if not raw_path:
+            continue
+        path_obj = Path(str(raw_path))
+        digest = _compute_sha256(path_obj)
+        if digest:
+            hashes[key] = {"sha256": digest, "size_bytes": path_obj.stat().st_size}
+    if hashes:
+        manifest["hashes"] = hashes
+
+    manifest_path = destination_dir / "run_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+__all__ = ["write_run_manifest"]


### PR DESCRIPTION
## Summary
- add CLI flags for run IDs, JSONL exports, and manifests while routing exports into per-run directories with logging
- implement JSONL exporters for raw segments and word metadata plus a provenance writer that records hashes, environment, and logs
- document the new output structure and CLI options in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5abb97764833095f9acaa3a967589