### PR TITLE
Support raw_segments.jsonl index in annotation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ JSON/JSONL padronizados com identificadores estáveis. A ferramenta aceita trans
 - `--transcript` aponta para o arquivo revisado.
 - `--format auto|txt|srt|vtt|json|jsonl` controla a detecção do formato. O padrão `auto` identifica pelo sufixo do arquivo.
 - `--export-format json|jsonl` define o formato de saída (padrão: `jsonl`).
+- `--raw-json` deve apontar para o arquivo `*.raw_segments.jsonl` gerado no estágio A para que o estágio B preserve os vínculos com os segmentos originais.
 
 Exemplo:
 

--- a/oratiotranscripta/annotate/jsonl.py
+++ b/oratiotranscripta/annotate/jsonl.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from typing import Any, Dict, Iterator, List, Mapping, MutableMapping, Optional, Sequence
 
 
+def _normalise_segment_id(value: Any) -> Any:
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if text.isdigit():
+        return int(text)
+    return text
+
+
 def _normalise_segment(segment: Mapping[str, Any]) -> Dict[str, Any]:
     if isinstance(segment, MutableMapping):
         return dict(segment)
@@ -37,15 +46,24 @@ def iter_records(
     base: Dict[str, Any] = {}
     if metadata is not None:
         base["metadata"] = dict(metadata)
+    raw_index: Optional[Mapping[str, Any]] = None
     if raw_transcription is not None:
         base["raw_transcription"] = dict(raw_transcription)
+        if isinstance(raw_transcription, Mapping):
+            segments_data = raw_transcription.get("segments")
+            if isinstance(segments_data, Mapping):
+                raw_index = segments_data
+            else:
+                raw_index = raw_transcription
 
     for position, segment in enumerate(normalised, start=1):
         record = dict(base)
+        source_index = segment.pop("_source_index")
+        _ensure_orig_reference(segment, raw_index)
         record.update(
             {
                 "id": f"utt-{position:04d}",
-                "segment_index": segment.pop("_source_index"),
+                "segment_index": source_index,
                 "segment": segment,
             }
         )
@@ -53,6 +71,48 @@ def iter_records(
         record.setdefault("end", segment.get("end"))
         record.setdefault("speaker", segment.get("speaker", ""))
         yield record
+
+
+def _ensure_orig_reference(
+    segment: Dict[str, Any], raw_index: Optional[Mapping[str, Any]]
+) -> None:
+    orig = {}
+    existing_orig = segment.get("orig")
+    if isinstance(existing_orig, Mapping):
+        orig.update(existing_orig)
+
+    raw_segment_ids: List[Any] = []
+    if "segments" in segment:
+        raw_values = segment.pop("segments")
+        if isinstance(raw_values, Sequence) and not isinstance(raw_values, (str, bytes)):
+            for value in raw_values:
+                normalised = _normalise_segment_id(value)
+                if normalised is not None:
+                    raw_segment_ids.append(normalised)
+    elif isinstance(orig.get("segment_ids"), Sequence) and not isinstance(
+        orig.get("segment_ids"), (str, bytes)
+    ):
+        for value in orig["segment_ids"]:  # type: ignore[index]
+            raw_segment_ids.append(_normalise_segment_id(value))
+
+    if raw_segment_ids:
+        orig["segment_ids"] = list(raw_segment_ids)
+        if raw_index:
+            resolved_segments = []
+            for value in raw_segment_ids:
+                key = str(_normalise_segment_id(value))
+                resolved = raw_index.get(key) if isinstance(raw_index, Mapping) else None
+                if resolved is None and isinstance(raw_index, Mapping):
+                    resolved = raw_index.get(value)  # type: ignore[index]
+                if isinstance(resolved, MutableMapping):
+                    resolved_segments.append(dict(resolved))
+                elif isinstance(resolved, Mapping):
+                    resolved_segments.append(dict(resolved))
+            if resolved_segments:
+                orig["segments"] = resolved_segments
+
+    if orig:
+        segment["orig"] = orig
 
 
 def build_records(

--- a/oratiotranscripta/annotate/manifest.py
+++ b/oratiotranscripta/annotate/manifest.py
@@ -74,11 +74,12 @@ def build_manifest(
         manifest["dataset"].setdefault("metrics", {}).update(dict(metrics))
 
     files_section: Dict[str, Any] = {}
+    raw_key = "raw_segments" if raw_path and raw_path.suffix.lower() == ".jsonl" else "raw"
     file_entries = {
         "tei": _describe_file(tei_path),
         "jsonl": _describe_file(jsonl_path),
         "metadata": _describe_file(metadata_path),
-        "raw": _describe_file(raw_path),
+        raw_key: _describe_file(raw_path),
     }
     for key, description in file_entries.items():
         if description:

--- a/oratiotranscripta/annotate/tei.py
+++ b/oratiotranscripta/annotate/tei.py
@@ -284,10 +284,20 @@ def _collect_words(
         return []
     collected: List[WordMetadata] = []
     for segment_id in utterance.segments:
-        for word in word_index.get(segment_id, ()):  # type: ignore[call-arg]
+        candidates = _lookup_words(word_index, segment_id)
+        for word in candidates:
             collected.append(word)
     collected.sort(key=lambda item: (_word_sort_key(item.start), _word_sort_key(item.end)))
     return collected
+
+
+def _lookup_words(word_index: WordIndex, segment_id: int) -> Sequence[WordMetadata]:
+    if segment_id in word_index:
+        return word_index[segment_id]
+    str_key = str(segment_id)
+    if str_key in word_index:  # type: ignore[operator]
+        return word_index[str_key]  # type: ignore[index]
+    return word_index.get(segment_id, ())  # type: ignore[call-arg]
 
 
 def _word_sort_key(value: Optional[float]) -> Tuple[int, float]:

--- a/tests/test_annotate_jsonl.py
+++ b/tests/test_annotate_jsonl.py
@@ -4,20 +4,30 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from oratiotranscripta.annotate import _load_raw_transcription
 from oratiotranscripta.annotate.jsonl import build_records
 
 
 def test_build_records_orders_segments_and_adds_ids():
     segments = [
-        {"start": 5.0, "text": "later", "speaker": "B"},
-        {"start": 2.0, "text": "early", "speaker": "A"},
-        {"text": "no timing"},
+        {"start": 5.0, "text": "later", "speaker": "B", "segments": [2]},
+        {"start": 2.0, "text": "early", "speaker": "A", "segments": [1]},
+        {"text": "no timing", "segments": [3, 4]},
     ]
+
+    raw_index = {
+        "segments": {
+            "1": {"segment_id": 1, "text": "first"},
+            "2": {"segment_id": 2, "text": "second"},
+            "3": {"segment_id": 3, "text": "third"},
+            "4": {"segment_id": 4, "text": "fourth"},
+        }
+    }
 
     records = build_records(
         segments,
         metadata={"project": "X"},
-        raw_transcription={"segments": []},
+        raw_transcription=raw_index,
     )
 
     assert [record["id"] for record in records] == ["utt-0001", "utt-0002", "utt-0003"]
@@ -29,3 +39,24 @@ def test_build_records_orders_segments_and_adds_ids():
     ]
     assert records[0]["metadata"]["project"] == "X"
     assert "raw_transcription" in records[0]
+    first_orig = records[0]["segment"]["orig"]
+    assert first_orig["segment_ids"] == [1]
+    assert first_orig["segments"][0]["text"] == "first"
+    assert "segments" not in records[0]["segment"]
+
+
+def test_load_raw_transcription_from_jsonl(tmp_path):
+    raw_path = tmp_path / "sample.raw_segments.jsonl"
+    raw_path.write_text(
+        """
+{"segment_id": 0, "text": "hi"}
+{"segment_id": 1, "text": "bye"}
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    loaded = _load_raw_transcription(raw_path)
+
+    assert loaded is not None
+    assert set(loaded["segments"].keys()) == {"0", "1"}
+    assert loaded["segments"]["0"]["text"] == "hi"

--- a/tests/test_annotate_manifest.py
+++ b/tests/test_annotate_manifest.py
@@ -40,8 +40,8 @@ def test_build_manifest_and_metadata_bundle(tmp_path):
     jsonl_path = tmp_path / "transcript.jsonl"
     jsonl_path.write_text("{}\n", encoding="utf-8")
 
-    raw_path = tmp_path / "raw.json"
-    raw_path.write_text("{}", encoding="utf-8")
+    raw_path = tmp_path / "raw_segments.jsonl"
+    raw_path.write_text("{}\n", encoding="utf-8")
 
     metadata_payload = build_normalised_metadata(metadata, metrics=metrics)
     metadata_file = tmp_path / "metadata.yml"
@@ -71,14 +71,14 @@ def test_build_manifest_and_metadata_bundle(tmp_path):
     assert written_manifest["dataset"]["metrics"] == metrics
 
     files = written_manifest["files"]
-    for key in ("tei", "jsonl", "metadata", "raw"):
+    for key in ("tei", "jsonl", "metadata", "raw_segments"):
         assert key in files
         described = files[key]
         expected_path = {
             "tei": tei_path,
             "jsonl": jsonl_path,
             "metadata": metadata_file,
-            "raw": raw_path,
+            "raw_segments": raw_path,
         }[key]
         assert described["path"] == str(expected_path)
         assert described["size"] == expected_path.stat().st_size


### PR DESCRIPTION
## Summary
- index raw segment exports when reading *.raw_segments.jsonl files
- preserve orig segment references when building JSONL/TEI outputs and update manifest naming
- document the Stage B requirement for raw_segments.jsonl and cover the behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b332d0f88330adb65fb289228b0c