### PR TITLE
Use YAML for metadata output when available

### DIFF
--- a/oratiotranscripta/annotate/__init__.py
+++ b/oratiotranscripta/annotate/__init__.py
@@ -320,7 +320,7 @@ def _write_manifest_bundle(
     if metadata is not None:
         metadata_file = manifest_path.with_name("metadata.yml")
         payload = build_normalised_metadata(metadata, metrics=metrics)
-        write_metadata_yaml(metadata_file, payload)
+        metadata_file = write_metadata_yaml(metadata_file, payload)
 
     jsonl_path = output_path if output_path and output_format == "jsonl" else None
     manifest = build_manifest(


### PR DESCRIPTION
## Summary
- prefer yaml.safe_dump for metadata exports when PyYAML is installed and fall back to JSON with an adjusted suffix otherwise
- propagate the actual metadata document path when building manifest bundles
- update manifest tests to validate YAML output and UTF-8 preservation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b579ae248330ac7bc35047b28fbe