### PR TITLE
Add PyYAML to optional extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ all = [
   "matplotlib>=3.10,<3.11",
   "torch>=2.0.0",
   "torchaudio>=2.0.0",
+  "PyYAML>=6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- ensure the `all` optional-dependency group pulls in PyYAML so metadata export defaults to YAML output

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e569364f2c8330950d707413ee18fb